### PR TITLE
Fixing grammar mistake in English reading time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,3 +54,4 @@
 - [Eli W. Hunter](https://github.com/elihunter173)
 - [Víctor López](https://github.com/viticlick)
 - [Anson VanDoren](https://github.com/anson-vandoren)
+- [Michael Lynch](https://github.com/mtlynch)

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -8,8 +8,7 @@ other = "tag"
 other = "series"
 
 [reading_time]
-one = "One minute read"
-other = "{{ .Count }} minutes read"
+other = "{{ .Count }}-minute read"
 
 [page_not_found]
 other = "Page Not Found"


### PR DESCRIPTION
Changing reading time from "XX minutes read" to "XX-minute read".

In English, a hyphen (-) joins a number to the noun that follows it. Also, the noun is always minute regardless of the number ('1-minute' and '2-minute' are correct, whereas '2-minutes' is incorrect).

Reference: https://www.grammarly.com/blog/hyphen/

>When numbers are used as the first part of a compound adjective, use a hyphen to connect them to the noun that follows them. This way, the reader knows that both words function like a unit to modify another noun. This applies whether the number is written in words or in digits.
>Example: The president of the company gave a 10-minute speech to the Board of Directors.